### PR TITLE
Fix: 匿名質問機能のテストコード改善

### DIFF
--- a/app/Http/Controllers/AnonymousQuestionController.php
+++ b/app/Http/Controllers/AnonymousQuestionController.php
@@ -37,7 +37,6 @@ class AnonymousQuestionController extends Controller
 
             $this->slack_client->viewsOpen($query_params);
 
-            return 'ok';
         } catch (SlackErrorResponse $e) {
             Log::info($e->getMessage());
             return 'error';
@@ -87,8 +86,6 @@ class AnonymousQuestionController extends Controller
                 ])
             ]);
 
-            return true;
-
         } catch (SlackErrorResponse $e) {
             Log::info($e->getMessage());
             return false;
@@ -103,8 +100,6 @@ class AnonymousQuestionController extends Controller
                 'channel' => config('const.slack_id.question_channel'),
                 'blocks' => json_encode(app()->make('App\Http\Controllers\BlockPayloads\AnonymousQuestionPayloadController')->createQuestionFormIntroductionBlocks())
             ]);
-
-            return true;
 
         } catch (SlackErrorResponse $e) {
             Log::info($e->getMessage());

--- a/app/Http/Controllers/AnonymousQuestionController.php
+++ b/app/Http/Controllers/AnonymousQuestionController.php
@@ -38,8 +38,10 @@ class AnonymousQuestionController extends Controller
             $this->slack_client->viewsOpen($query_params);
 
         } catch (SlackErrorResponse $e) {
-            Log::info($e->getMessage());
-            return 'error';
+            $error_message = $e->getMessage();
+
+            Log::info($error_message);
+            echo $error_message;
         }
     }
 
@@ -87,10 +89,14 @@ class AnonymousQuestionController extends Controller
             ]);
 
         } catch (SlackErrorResponse $e) {
-            Log::info($e->getMessage());
-            return false;
+            $error_message = $e->getMessage();
+
+            Log::info($error_message);
+            echo $error_message;
         }
-    }/**
+    }
+    
+    /**
     * 匿名質問フォームを紹介するメッセージを送る
     */
     public function introduceQuestionForm ()
@@ -102,8 +108,10 @@ class AnonymousQuestionController extends Controller
             ]);
 
         } catch (SlackErrorResponse $e) {
-            Log::info($e->getMessage());
-            return false;
+            $error_message = $e->getMessage();
+
+            Log::info($error_message);
+            echo $error_message;
         }
     }
 } 

--- a/tests/Feature/Controllers/AnonymousQuestionTest.php
+++ b/tests/Feature/Controllers/AnonymousQuestionTest.php
@@ -89,10 +89,7 @@ class AnonymousQuestionTest extends TestCase
         $dummy_request = new Request();
         $dummy_request->replace(['trigger_id'=>'12345.98765.abcd2358fdea']);
 
-        $this->assertEquals(
-            'ok', 
-            $anonymous_question_controller->openQuestionForm($dummy_request)
-        );
+        $anonymous_question_controller->openQuestionForm($dummy_request);
     }
 
     /**
@@ -151,7 +148,7 @@ class AnonymousQuestionTest extends TestCase
         $slack_client_mock = $this->provideSlackClientMock();
         $anonymous_question_controller = new AnonymousQuestionController($slack_client_mock);
 
-        $this->assertTrue($anonymous_question_controller->sendQuestionToChannel($dummy_payload));
+        $anonymous_question_controller->sendQuestionToChannel($dummy_payload);
     }
 
     /**
@@ -203,7 +200,7 @@ class AnonymousQuestionTest extends TestCase
         $slack_client_mock = $this->provideSlackClientMock();
         $anonymous_question_controller = new AnonymousQuestionController($slack_client_mock);
 
-        $this->assertTrue($anonymous_question_controller->introduceQuestionForm());
+        $anonymous_question_controller->introduceQuestionForm();
     }
 
     /**

--- a/tests/Feature/Controllers/AnonymousQuestionTest.php
+++ b/tests/Feature/Controllers/AnonymousQuestionTest.php
@@ -114,10 +114,8 @@ class AnonymousQuestionTest extends TestCase
         $dummy_request = new Request();
         $dummy_request->replace(['trigger_id'=>'']);
 
-        $this->assertEquals(
-            'error',
-            $anonymous_question_controller->openQuestionForm($dummy_request)
-        );
+        $anonymous_question_controller->openQuestionForm($dummy_request); 
+        $this->expectOutputString('Slack returned error code "dummy exception: viewsOpen"'); 
     }
 
     /**
@@ -178,7 +176,8 @@ class AnonymousQuestionTest extends TestCase
         $slack_client_mock = $this->provideSlackClientMock();
         $anonymous_question_controller = new AnonymousQuestionController($slack_client_mock);
     
-        $this->assertFalse($anonymous_question_controller->sendQuestionToChannel($dummy_payload));
+        $anonymous_question_controller->sendQuestionToChannel($dummy_payload);
+        $this->expectOutputString('Slack returned error code "dummy exception: chatPostMessage"'); 
     }
 
     /**
@@ -221,6 +220,7 @@ class AnonymousQuestionTest extends TestCase
         $slack_client_mock = $this->provideSlackClientMock();
         $anonymous_question_controller = new AnonymousQuestionController($slack_client_mock);
 
-        $this->assertFalse($anonymous_question_controller->introduceQuestionForm());
+        $anonymous_question_controller->introduceQuestionForm();
+        $this->expectOutputString('Slack returned error code "dummy exception: chatPostMessage"'); 
     }
 }


### PR DESCRIPTION
slackにレスポンスが返されるのを防ぐため、try文内ではreturn を返さないような仕様に変更しました。

メモ：
テストコードに``@doesNotPerformAssertions``を追加すると``This test is annotated with "@doesNotPerformAssertions" but performed 3 assertions``というメッセージが返ってきました。まだ特定できてませんが、どうやらアサーション以外で検証されている箇所があるようです。アノテーションがなくても問題なさそうなのでコミットしました。