### PR TITLE
Fix:slackのチャンネルIDの格納方法を変更

### DIFF
--- a/.github/workflows/run-tests-in-develop-branch.yml
+++ b/.github/workflows/run-tests-in-develop-branch.yml
@@ -35,4 +35,11 @@ jobs:
         DB_TEST_USERNAME: root
         DB_TEST_PASSWORD: root
         SLACK_TOKEN: sample
+        SLACK_ID_GENERAL: C01MGFXJSD8
+        SLACK_ID_ADMINISTRATOR: U01MGFXHWF4
+        SLACK_ID_MENTOR_CHANNEL: C01TCU28B28
+        SLACK_ID_QUESTION_CHANNEL: C01SM8H8TDY
+        SLACK_ID_MENTORS_NAME: 今川メンター,菊池メンター,工藤メンター,noppe(平野)メンター,山際メンター
+        SLACK_ID_MENTORS_DESCRIPTION: Ruby、Scala、PHP、AWSなど,Kotlin、flutterなど,PHP、Go、ハッカソンの審査/勝ち方など,Swift、個人開発など,Python、Go、機械学習、就活相談など
+        SLACK_ID_MENTORS_ID: U01PE3ZUX5E,U01SM47RJLT,UU6RPHQGG,UU6RPJUJU,UTZC4SKPV
       run: vendor/bin/phpunit

--- a/app/Http/Controllers/AnonymousQuestionController.php
+++ b/app/Http/Controllers/AnonymousQuestionController.php
@@ -20,12 +20,12 @@ class AnonymousQuestionController extends Controller
         }
     }
 
-   /**
-    * /ask-questionのコマンドの応答としてモーダルを表示
-    *
-    * @param Request $request
-    */
-    public function openQuestionForm (Request $request) 
+    /**
+     * /ask-questionのコマンドの応答としてモーダルを表示
+     *
+     * @param Request $request
+     */
+    public function openQuestionForm(Request $request)
     {
         response('', 200)->send();
 
@@ -44,20 +44,20 @@ class AnonymousQuestionController extends Controller
         }
     }
 
-   /**
-    * 受け付けた匿名質問をメッセージとして公開チャンネルに流す
-    * 
-    * @param Request $request
-    * @var string $mention メンション先を定義
-    */
-    public function sendQuestionToChannel ($payload)
+    /**
+     * 受け付けた匿名質問をメッセージとして公開チャンネルに流す
+     *
+     * @param Request $request
+     * @var string $mention メンション先を定義
+     */
+    public function sendQuestionToChannel($payload)
     {
         try {
             $user_inputs = $payload['view']['state']['values'];
             $mentor_number = intval($user_inputs['mentors-block']['mentor']['selected_option']['value']);
-            $question_sentence = $user_inputs['question-block']['question']['value'];    
+            $question_sentence = $user_inputs['question-block']['question']['value'];
 
-            $mention = $mentor_number == 6 ? ' 全体へ' : config("const.slack_id.mentors")[$mentor_number];
+            $mention = $mentor_number == count(config("const.slack_id.mentors")) ? ' 全体へ' : config("const.slack_id.mentors")[$mentor_number]['id'];
             $this->slack_client->chatPostMessage([
                 'channel' => config('const.slack_id.question_channel'),
                 'username' => '匿名の相談です',
@@ -88,7 +88,6 @@ class AnonymousQuestionController extends Controller
             ]);
 
             return true;
-
         } catch (SlackErrorResponse $e) {
             Log::info($e->getMessage());
             return false;
@@ -96,7 +95,7 @@ class AnonymousQuestionController extends Controller
     }/**
     * 匿名質問フォームを紹介するメッセージを送る
     */
-    public function introduceQuestionForm ()
+    public function introduceQuestionForm()
     {
         try {
             $this->slack_client->chatPostMessage([
@@ -105,10 +104,9 @@ class AnonymousQuestionController extends Controller
             ]);
 
             return true;
-
         } catch (SlackErrorResponse $e) {
             Log::info($e->getMessage());
             return false;
         }
     }
-} 
+}

--- a/app/Http/Controllers/BlockPayloads/AnonymousQuestionPayloadController.php
+++ b/app/Http/Controllers/BlockPayloads/AnonymousQuestionPayloadController.php
@@ -7,12 +7,12 @@ use Illuminate\Http\Request;
 
 class AnonymousQuestionPayloadController extends Controller
 {
-   /**
-    * 匿名質問フォームを紹介するメッセージを構成するブロックを作成する
-    *
-    * @return array
-    */
-    public function createQuestionFormIntroductionBlocks () 
+    /**
+     * 匿名質問フォームを紹介するメッセージを構成するブロックを作成する
+     *
+     * @return array
+     */
+    public function createQuestionFormIntroductionBlocks()
     {
         return [
             [
@@ -52,9 +52,9 @@ class AnonymousQuestionPayloadController extends Controller
     *
     * @return array
     */
-    public function createQuestionFormView () 
+    public function createQuestionFormView()
     {
-        return [
+        $view = [
                 "type"=> "modal",
                 "callback_id" => "ask_questions",
                 "title"=> [
@@ -117,62 +117,6 @@ class AnonymousQuestionPayloadController extends Controller
                                 "type" => "radio_buttons",
                                 "action_id" => "mentor",
                                 "options" => [
-                                    [
-                                        "text" => [
-                                            "type" => "plain_text",
-                                            "text" => "今川メンター：Ruby, Scala, PHP, AWSなど",
-                                            "emoji" => true
-                                        ],
-                                        "value" => "0"
-                                    ],
-                                    [
-                                        "text" => [
-                                            "type" => "plain_text",
-                                            "text" => "菊池メンター：Kotlin, flutter など",
-                                            "emoji" => true
-                                        ],
-                                        "value" => "1"
-                                    ],
-                                    [
-                                        "text" => [
-                                            "type" => "plain_text",
-                                            "text" => "工藤メンター：PHP, Go, ハッカソンの審査/勝ち方 など",
-                                            "emoji" => true
-                                        ],
-                                        "value" => "2"
-                                    ],
-                                    [
-                                        "text" => [
-                                            "type" => "plain_text",
-                                            "text" => "近藤メンター：JavaScript, TypeScript, フロントエンド全般 など",
-                                            "emoji" => true
-                                        ],
-                                        "value" => "3"
-                                    ],
-                                    [
-                                        "text" => [
-                                            "type" => "plain_text",
-                                            "text" => "noppe(平野)メンター：Swift, 個人開発 など",
-                                            "emoji" => true
-                                        ],
-                                        "value" => "4"
-                                    ],
-                                    [
-                                        "text" => [
-                                            "type" => "plain_text",
-                                            "text" => "山際メンター：Python, Go, 機械学習, 就活相談 など",
-                                            "emoji" => true
-                                        ],
-                                        "value" => "5"
-                                    ],
-                                    [
-                                        "text" => [
-                                            "type" => "plain_text",
-                                            "text" => "その他",
-                                            "emoji" => true
-                                        ],
-                                        "value" => "6"
-                                    ]
                                 ]
                             ]
                         ]
@@ -193,5 +137,27 @@ class AnonymousQuestionPayloadController extends Controller
                     ]
                 ]
             ];
+
+        foreach (config('const.slack_id.mentors') as $key => $mentor) {
+            $view['blocks'][6]['elements'][0]['options'][] = [
+                "text" => [
+                    "type" => "plain_text",
+                    "text" => $mentor['name']."：".$mentor['description'],
+                    "emoji" => true
+                ],
+                "value" => "$key"
+            ];
+        }
+
+        $view['blocks'][6]['elements'][0]['options'][] = [
+            "text" => [
+                "type" => "plain_text",
+                "text" => "その他",
+                "emoji" => true
+            ],
+            "value" => (string)($key+1)
+        ];
+
+        return $view;
     }
 }

--- a/app/Http/Controllers/BlockPayloads/CounselingPayloadController.php
+++ b/app/Http/Controllers/BlockPayloads/CounselingPayloadController.php
@@ -43,7 +43,7 @@ class CounselingPayloadController extends Controller
      */
     public function getModalConstitution()
     {
-        return [
+        $view = [
             "callback_id" => "apply_counseling",
             "title" => [
                 "type" => "plain_text",
@@ -63,47 +63,36 @@ class CounselingPayloadController extends Controller
             ],
             "blocks" => [
                 [
-                    "type" => "input",
-                    "block_id" => "mentor_slack_id",
-                    "label" => [
-                        "type" => "plain_text",
-                        "text" => "相談したいメンター",
-                        "emoji" => true
-                    ],
-                    "element" => [
-                        "type" => "static_select",
-                        "placeholder" => [
-                            "type" => "plain_text",
-                            "text" => "メンターさんを選択してください。",
-                            "emoji" => true
-                        ],
-                        "options" => [
-                            [
-                                "text" => [
-                                    "type" => "plain_text",
-                                    "text" => "メンター1",
-                                    "emoji" => true
-                                ],
-                                "value" => config('const.slack_id.mentors')[0]
-                            ],
-                            [
-                                "text" => [
-                                    "type" => "plain_text",
-                                    "text" => "メンター2",
-                                    "emoji" => true
-                                ],
-                                "value" => config('const.slack_id.mentors')[1]
+                    "type" => "divider"
+                ],
+                [
+                    "type" => "section",
+                    "text" => [
+                        "type" => "mrkdwn",
+                        "text" => ":pencil2: *質問したいメンター*"
+                    ]
+                ],
+                [
+                    "type" => "actions",
+                    "block_id" => "mentor",
+                    "elements" => [
+                        [
+                            "type" => "radio_buttons",
+                            "action_id" => "mentor",
+                            "options" => [
                             ]
                         ],
-                        "action_id" => "mentor_slack_id"
                     ]
+                ],
+                [
+                    "type" => "divider"
                 ],
                 [
                     "type" => "input",
                     "block_id" => "consultation_content",
                     "label" => [
                         "type" => "plain_text",
-                        "text" => "どんなことを質問/相談したいですか？",
+                        "text" => ":pencil2:どんなことを質問/相談したいですか？",
                         "emoji" => true
                     ],
                     "element" => [
@@ -117,14 +106,14 @@ class CounselingPayloadController extends Controller
                     ]
                 ],
                 [
+                    "type" => "divider"
+                ],
+                [
                     "type" => "section",
                     "text" => [
                         "type" => "mrkdwn",
-                        "text" => "*開催希望日時*\n※明日以降の日程を入力してください。"
+                        "text" => ":pencil2:*開催希望日時*\n※明日以降の日程を入力してください。"
                     ]
-                ],
-                [
-                    "type" => "divider"
                 ],
                 [
                     "type" => "input",
@@ -179,6 +168,19 @@ class CounselingPayloadController extends Controller
                 ]
             ]
         ];
+
+        foreach (config('const.slack_id.mentors') as $key => $mentor) {
+            $view['blocks'][2]['elements'][0]['options'][] = [
+                "text" => [
+                    "type" => "plain_text",
+                    "text" => $mentor['name']."：".$mentor['description'],
+                    "emoji" => true
+                ],
+                "value" => "$key"
+            ];
+        }
+
+        return $view;
     }
 
     /**
@@ -190,8 +192,10 @@ class CounselingPayloadController extends Controller
     public function getNotifyApplyBlockConstitution($payload)
     {
         //変数に変換
-        $mentor_slack_id = $payload['view']['state']['values']['mentor_slack_id']['mentor_slack_id']['selected_option']['value'];
-        $mentor_name = $payload['view']['state']['values']['mentor_slack_id']['mentor_slack_id']['selected_option']['text']['text'];
+        $mentor_number = $payload['view']['state']['values']['mentor']['mentor']['selected_option']['value'];
+        $mentor_slack_id = config("const.slack_id.mentors")[$mentor_number]['id'];
+        $mentor_name = config("const.slack_id.mentors")[$mentor_number]['name'];
+
         $consultation_content = $payload['view']['state']['values']['consultation_content']['consultation_content']['value'];
 
         $first_preferred_date_time = $payload['view']['state']['values']['first_preferred_date_time']['first_preferred_date_time']['value'];
@@ -214,7 +218,7 @@ class CounselingPayloadController extends Controller
                 "type" => "section",
                 "text" => [
                     "type" => "mrkdwn",
-                    "text" => "*相談したいメンター*\n{$mentor_name}さん <@${mentor_slack_id}>\n*相談内容*\n{$consultation_content}\n*第一希望*\n{$first_preferred_date_time}\n*第二希望*\n{$second_preferred_date_time}\n*第三希望*\n4{$third_preferred_date_time}"
+                    "text" => "*相談したいメンター*\n{$mentor_name}さん <@${mentor_slack_id}>\n*相談内容*\n{$consultation_content}\n*第一希望*\n{$first_preferred_date_time}\n*第二希望*\n{$second_preferred_date_time}\n*第三希望*\n{$third_preferred_date_time}"
                 ]
             ],
             [
@@ -239,8 +243,9 @@ class CounselingPayloadController extends Controller
     public function getCompletedApplyBlockConstitution($payload)
     {
         //変数に変換
-        $mentor_slack_id = $payload['view']['state']['values']['mentor_slack_id']['mentor_slack_id']['selected_option']['value'];
-        $mentor_name = $payload['view']['state']['values']['mentor_slack_id']['mentor_slack_id']['selected_option']['text']['text'];
+        $mentor_number = $payload['view']['state']['values']['mentor']['mentor']['selected_option']['value'];
+        $mentor_slack_id = config("const.slack_id.mentors")[$mentor_number]['id'];
+        $mentor_name = config("const.slack_id.mentors")[$mentor_number]['name'];
         $consultation_content = $payload['view']['state']['values']['consultation_content']['consultation_content']['value'];
 
         $first_preferred_date_time = $payload['view']['state']['values']['first_preferred_date_time']['first_preferred_date_time']['value'];
@@ -266,7 +271,7 @@ class CounselingPayloadController extends Controller
                 "type" => "section",
                 "text" => [
                     "type" => "mrkdwn",
-                    "text" => "*名前*\n${user_name}さん <@${user_id}>\n*相談したいメンター*\n{$mentor_name}さん <@${mentor_slack_id}>\n*相談内容*\n{$consultation_content}\n*第一希望*\n{$first_preferred_date_time}\n*第二希望*\n{$second_preferred_date_time}\n*第三希望*\n4{$third_preferred_date_time}"
+                    "text" => "*名前*\n${user_name}さん <@${user_id}>\n*相談したいメンター*\n{$mentor_name}さん <@${mentor_slack_id}>\n*相談内容*\n{$consultation_content}\n*第一希望*\n{$first_preferred_date_time}\n*第二希望*\n{$second_preferred_date_time}\n*第三希望*\n{$third_preferred_date_time}"
                 ]
             ],
             [

--- a/config/const.php
+++ b/config/const.php
@@ -1,17 +1,22 @@
 <?php
 
-return [
-    'slack_id' => [
-        'general' => 'C01MGFXJSD8',
-        'administrator' => 'U01MGFXHWF4',
-        'mentor_channel' => 'C01TCU28B28',
-        'question_channel' => 'C01SM8H8TDY',
-        'mentors' => [
-            // 今川メンター, 菊池メンター, 工藤メンター, 近藤メンター, 平野メンター, 山際メンター
-            // 'UU6S9J5EZ', 'UTY2QH0RG', 'UU6RPHQGG', 'U01CE7ZL1T3', 'UU6RPJUJU', 'UTZC4SKPV'
+$mentor_names = array_map('trim', explode(',', env('SLACK_ID_MENTORS_NAME')));
+$mentor_descriptions = array_map('trim', explode(',', env('SLACK_ID_MENTORS_DESCRIPTION')));
+$mentor_ids = array_map('trim', explode(',', env('SLACK_ID_MENTORS_ID')));
 
-            // テスト用
-            'U01PE3ZUX5E', 'U01SM47RJLT', 'UU6RPHQGG', 'U01CE7ZL1T3', 'UU6RPJUJU', 'UTZC4SKPV'
-        ]
+$const = [
+    'slack_id' => [
+        'general' => env('SLACK_ID_GENERAL'),
+        'administrator' => env('SLACK_ID_ADMINISTRATOR'),
+        'mentor_channel' => env('SLACK_ID_MENTOR_CHANNEL'),
+        'question_channel' => env('SLACK_ID_QUESTION_CHANNEL'),
     ]
 ];
+
+for ($i=0; $i < count($mentor_names); $i++) {
+    $const['slack_id']['mentors'][$i]['name'] = $mentor_names[$i];
+    $const['slack_id']['mentors'][$i]['description'] = $mentor_descriptions[$i];
+    $const['slack_id']['mentors'][$i]['id'] = $mentor_ids[$i];
+}
+
+return $const;


### PR DESCRIPTION
slackのチャンネルIDの格納場所をconfigから.envに変更しました。
それに伴い、関数の処理方法も変更しています。